### PR TITLE
feat-implemented the color scheme on the currency converter

### DIFF
--- a/src/layout/currencyConverter/CurrencyConverter.tsx
+++ b/src/layout/currencyConverter/CurrencyConverter.tsx
@@ -3,7 +3,7 @@ import { cryptoCurrencies } from '@/data/cryptoCurrencies';
 import { fiatCurrencies } from '@/data/fiatCurrencies';
 import { CurrencyInput } from './CurrencyInput';
 import { SwapButton } from './SwapButton';
-import { useState } from 'react';
+import { use, useState } from 'react';
 
 const CurrencyConverter = () => {
     const {
@@ -24,6 +24,7 @@ const CurrencyConverter = () => {
     // Mantener un estado local para las listas de monedas
     const [fromList, setFromList] = useState(cryptoCurrencies);
     const [toList, setToList] = useState(fiatCurrencies);
+    const [isActive,setIsActive] = useState(false);
 
     // Función personalizada para manejar el swap
     const handleSwapWithLists = () => {
@@ -45,6 +46,8 @@ const CurrencyConverter = () => {
                 onAmountChange={handleFromAmountChange}
                 type="from"
                 currencies={fromList}
+                isActive={isActive}
+                setActive={setIsActive}
             />
 
             <div className="flex justify-center -my-1">
@@ -59,6 +62,8 @@ const CurrencyConverter = () => {
                 onAmountChange={handleToAmountChange}
                 type="to"
                 currencies={toList}
+                isActive={isActive}
+                setActive={setIsActive}
             />
         </div>
         </>

--- a/src/layout/currencyConverter/CurrencyInput.tsx
+++ b/src/layout/currencyConverter/CurrencyInput.tsx
@@ -1,6 +1,6 @@
 import { Currency } from '@/types/currency';
 import { CurrencySelect } from './CurrencySelect';
-import { useState } from 'react';
+import { useEffect } from 'react';
 
 interface CurrencyInputProps {
   label: string;
@@ -10,28 +10,36 @@ interface CurrencyInputProps {
   onAmountChange: (value: string) => void;
   type: 'from' | 'to';
   currencies: Currency[];
+  isActive: boolean;
+  setActive: (active: boolean) => void;
 }
 
-export const CurrencyInput: React.FC<
-  CurrencyInputProps
-> = ({
+export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   label,
   selectedCurrency,
   onCurrencySelect,
   amount,
   onAmountChange,
   type,
-  currencies
+  currencies,
+  isActive,
+  setActive,
 }: CurrencyInputProps) => {
 
-const [isFocused, setIsFocused] = useState(false)
+  useEffect(() => {
+    if (!amount) {
+      setActive(false);
+    }
+  }, [amount, setActive]);
 
   return (
-    <div className={`
-      rounded-[24px] p-[5px] 
-      ${isFocused ? "bg-gradient-to-br from-[#5c462e]  to-[#402d50]" : "bg-zinc-800"}
-      transition-all duration-300
-    `}>
+    <div
+      className={`
+        rounded-[24px] p-[5px] 
+        ${isActive ? "bg-gradient-to-br from-[#5c462e]  to-[#402d50]" : "bg-zinc-800"}
+        transition-all duration-300
+      `}
+    >
       <div className="bg-[#141414] rounded-[19px] p-4 border border-white/5">
         <div className={`${type === 'from' ? 'flex justify-start' : 'flex justify-end'} mb-2`}>
           <label className="text-[14px] text-white/50">{label}</label>
@@ -46,9 +54,11 @@ const [isFocused, setIsFocused] = useState(false)
           <input
             type="number"
             value={amount}
-            onChange={(e) => onAmountChange(e.target.value)}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
+            onChange={(e) => {
+              onAmountChange(e.target.value);
+              setActive(true);
+            }}
+            onFocus={() => setActive(true)}
             placeholder="0"
             className={`bg-transparent w-full focus:outline-none placeholder-white/50 text-[20px] ${type === 'from' ? 'text-right' : 'text-left'}`}
             min="0"
@@ -58,4 +68,4 @@ const [isFocused, setIsFocused] = useState(false)
       </div>
     </div>
   );
-}
+};

--- a/src/layout/currencyConverter/CurrencyInput.tsx
+++ b/src/layout/currencyConverter/CurrencyInput.tsx
@@ -1,5 +1,6 @@
 import { Currency } from '@/types/currency';
 import { CurrencySelect } from './CurrencySelect';
+import { useState } from 'react';
 
 interface CurrencyInputProps {
   label: string;
@@ -22,8 +23,15 @@ export const CurrencyInput: React.FC<
   type,
   currencies
 }: CurrencyInputProps) => {
+
+const [isFocused, setIsFocused] = useState(false)
+
   return (
-    <div className="rounded-[24px] p-[1px] border-4 border-white/5">
+    <div className={`
+      rounded-[24px] p-[5px] 
+      ${isFocused ? "bg-gradient-to-br from-[#5c462e]  to-[#402d50]" : "bg-zinc-800"}
+      transition-all duration-300
+    `}>
       <div className="bg-[#141414] rounded-[19px] p-4 border border-white/5">
         <div className={`${type === 'from' ? 'flex justify-start' : 'flex justify-end'} mb-2`}>
           <label className="text-[14px] text-white/50">{label}</label>
@@ -39,6 +47,8 @@ export const CurrencyInput: React.FC<
             type="number"
             value={amount}
             onChange={(e) => onAmountChange(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
             placeholder="0"
             className={`bg-transparent w-full focus:outline-none placeholder-white/50 text-[20px] ${type === 'from' ? 'text-right' : 'text-left'}`}
             min="0"

--- a/src/layout/currencyConverter/CurrencyInput.tsx
+++ b/src/layout/currencyConverter/CurrencyInput.tsx
@@ -1,6 +1,6 @@
 import { Currency } from '@/types/currency';
 import { CurrencySelect } from './CurrencySelect';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 interface CurrencyInputProps {
   label: string;
@@ -25,10 +25,13 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   isActive,
   setActive,
 }: CurrencyInputProps) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const [hasTyped, setHasTyped] = useState(false);
 
   useEffect(() => {
     if (!amount) {
       setActive(false);
+      setHasTyped(false);
     }
   }, [amount, setActive]);
 
@@ -36,7 +39,7 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
     <div
       className={`
         rounded-[24px] p-[5px] 
-        ${isActive ? "bg-gradient-to-br from-[#5c462e]  to-[#402d50]" : "bg-zinc-800"}
+        ${(isActive || isFocused) ? "bg-gradient-to-br from-[#5c462e] to-[#402d50]" : "bg-zinc-800"}
         transition-all duration-300
       `}
     >
@@ -56,9 +59,13 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
             value={amount}
             onChange={(e) => {
               onAmountChange(e.target.value);
+              setHasTyped(true);
               setActive(true);
             }}
-            onFocus={() => setActive(true)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => {
+              if (!hasTyped) setIsFocused(false);
+            }}
             placeholder="0"
             className={`bg-transparent w-full focus:outline-none placeholder-white/50 text-[20px] ${type === 'from' ? 'text-right' : 'text-left'}`}
             min="0"


### PR DESCRIPTION
### Description

closes #6 

> This PR Implements the color scheme on the currency converter input fields


### Visual Improvements
>Took off the ```border-4``` and ```border-white/60``` on the outer container as it interferes with the gradient, it still looks accurate

### proof

![image](https://github.com/user-attachments/assets/6bcf5122-6275-42a3-a3c0-a8ec188cb0cd)



### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).