### PR TITLE
feat(web): create header component for developer page

### DIFF
--- a/src/components/HeaderDeveloper.tsx
+++ b/src/components/HeaderDeveloper.tsx
@@ -1,0 +1,29 @@
+import { FileCode, House } from 'lucide-react'
+import Header from './Header'
+
+export function HeaderDeveloper() {
+  return (
+    <section>
+      <Header />
+
+      <div className="max-w-[546px] mx-auto pt-7 pb-9 px-4">
+        <div className="flex text-white/50 gap-4 text-[12px] items-center pb-9">
+          <div className="flex items-center gap-2">
+            <House />
+            Home
+          </div>
+          <span className="text-[12px]">/</span>
+          <div className="flex items-center gap-2">
+            <FileCode />
+            Docs
+          </div>
+        </div>
+
+        <h3 className="text-white text-[22px] font-medium">For Developers</h3>
+        <p className="text-white/50 text-[14px] pt-2">
+          Get rate data rates.noblocks.xyz/for_developers
+        </p>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
### Description

> The header component of the developer page was created
> Figma's design was respected in the component
> component is responsive on desktop, tablet, and mobile
<img width="1310" alt="Captura de pantalla 2025-04-26 a la(s) 2 53 00 a  m" src="https://github.com/user-attachments/assets/cbff3e9d-8d5d-4104-bb18-0a0740abe00e" />



### References

> close https://github.com/paycrest/stablecoin-rates-UI/issues/15

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).