### PR TITLE
fix: update country codes for Congolese Franc, Lao Kip, and CFA Francs

### DIFF
--- a/src/data/currenciesCodes.json
+++ b/src/data/currenciesCodes.json
@@ -130,7 +130,7 @@
     "currency_name": "Canadian Dollar"
   },
   {
-    "country_code": "N/A",
+    "country_code": "CD",
     "currency_code": "CDF",
     "currency_name": "Congolese Franc"
   },
@@ -400,7 +400,7 @@
     "currency_name": "Kazakhstani Tenge"
   },
   {
-    "country_code": "N/A",
+    "country_code": "LA",
     "currency_code": "LAK",
     "currency_name": "Lao Kip"
   },
@@ -760,7 +760,7 @@
     "currency_name": "Samoan tālā"
   },
   {
-    "country_code": "N/A",
+    "country_code": "CF",
     "currency_code": "XAF",
     "currency_name": "Central African CFA Franc"
   },
@@ -775,12 +775,12 @@
     "currency_name": "Special Drawing Rights"
   },
   {
-    "country_code": "N/A",
+    "country_code": "CF",
     "currency_code": "XOF",
     "currency_name": "West African CFA franc"
   },
   {
-    "country_code": "N/A",
+    "country_code": "PF",
     "currency_code": "XPF",
     "currency_name": "CFP Franc"
   },


### PR DESCRIPTION
### Description

This pull request updates the `src/data/currenciesCodes.json` file to provide more accurate country codes for several currency entries that previously used `"N/A"`. The changes help ensure that each currency is correctly associated with its respective country or region.

**Corrections to country codes for currencies:**

* Set `country_code` to `"CD"` for the Congolese Franc (`"CDF"`)
* Set `country_code` to `"LA"` for the Lao Kip (`"LAK"`)
* Set `country_code` to `"CF"` for the Central African CFA Franc (`"XAF"`)
* Set `country_code` to `"CF"` for the West African CFA franc (`"XOF"`)
* Set `country_code` to `"PF"` for the CFP Franc (`"XPF"`)



### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

see the below loom video to see what it looks like.

[https://www.loom.com/share/ba19dc93716b47b79b5484d4ef980f4c?sid=b87de305-3c41-44b8-8edd-fc3856627ec6](https://www.loom.com/share/ba19dc93716b47b79b5484d4ef980f4c?sid=b87de305-3c41-44b8-8edd-fc3856627ec6)


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).