### PR TITLE
fix: update country code for Macanese Pataca

### DIFF
--- a/src/data/currenciesCodes.json
+++ b/src/data/currenciesCodes.json
@@ -460,7 +460,7 @@
     "currency_name": "Mongolian tögrög"
   },
   {
-    "country_code": "N/A",
+    "country_code": "MO",
     "currency_code": "MOP",
     "currency_name": "Macanese Pataca"
   },


### PR DESCRIPTION
### Description

This pull request updates the country code for the Macanese Pataca currency in the `currenciesCodes.json` data file to ensure accuracy.

Data correction:

* Changed the `country_code` for the Macanese Pataca (`currency_code`: "MOP") from `"N/A"` to `"MO"` in `src/data/currenciesCodes.json`.

### References

Fixes an issue Chibie raised.


### Testing

Just pull the code and run the codebase, then select 'MOP' in the currency converter dropdown.

<img width="1909" height="1039" alt="Screenshot 2025-11-04 at 07 01 29" src="https://github.com/user-attachments/assets/ccb82326-4f87-46a0-a281-4128d558041e" />


- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated currency data with the correct country code for Macanese Pataca.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->